### PR TITLE
Problem: API coverage is partial and manual

### DIFF
--- a/ndn-cpp/default.nix
+++ b/ndn-cpp/default.nix
@@ -16,6 +16,7 @@ stdenv.mkDerivation {
   enableParallelBuilding = true;
   nativeBuildInputs = [ doxygen pkgconfig protobuf ];
   buildInputs = [ openssl zlib ];
+#  patches = [ ./ndn-cpp.diff ];
 
   meta = with stdenv.lib; {
     homepage = http://named-data.net/;

--- a/swig/default.nix
+++ b/swig/default.nix
@@ -9,11 +9,26 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ libtool swig ndn-cpp ];
   src = ./.;
   buildPhase = ''
-    swig -I${ndn-cpp.out}/include -c++ -mzscheme -declaremodule face.i
+    for i in $(cd ${ndn-cpp.out}/include/ndn-cpp; find lite -name '*.hpp'); do
+      mkdir -p ''${i%/*}
+      i_base=''${i##*/}
+      i_base_under=''${i_base//-/_}
+      cat > ''${i%.hpp}.i <<EOF
+    %module ''${i_base_under%.hpp}
+    %{
+    #include <ndn-cpp/$i>
+    %}
+
+    %include <ndn-cpp/$i>
+    EOF
+    swig -I${ndn-cpp.out}/include -c++ -mzscheme -declaremodule ''${i%.hpp}.i
+    done
   '';
 
   installPhase = ''
-    mkdir -p $out
-    cp face_wrap.cxx $out/
+    for i in $(find . -name '*_wrap.cxx'); do
+      mkdir -p $out/''${i%/*}
+      cp $i $out/$i
+    done
   '';
 }

--- a/swig/face.i
+++ b/swig/face.i
@@ -1,6 +1,0 @@
-%module face
-%{
-#include <ndn-cpp/face.hpp>
-%}
-
-%include <ndn-cpp/face.hpp>


### PR DESCRIPTION
Solution: Generate the interface file from the *.hpp file names.

Swig cannot handle the full API, see #3, but the Lite API works well.
Wrapping that should give us some convenience over working with the C
API directly.