### PR TITLE
Problem: Not generating a Racket package from bindings

### DIFF
--- a/ndn-cpp/default.nix
+++ b/ndn-cpp/default.nix
@@ -16,7 +16,6 @@ stdenv.mkDerivation {
   enableParallelBuilding = true;
   nativeBuildInputs = [ doxygen pkgconfig protobuf ];
   buildInputs = [ openssl zlib ];
-#  patches = [ ./ndn-cpp.diff ];
 
   meta = with stdenv.lib; {
     homepage = http://named-data.net/;

--- a/pins/racket2nix/bump.sh
+++ b/pins/racket2nix/bump.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env nix-shell
+#! nix-shell --quiet -p bash gawk git nix-prefetch-git -i bash
+
+set -euo pipefail
+
+URL=https://github.com/fractalide/racket2nix.git
+DEFAULT_REV=refs/heads/master
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+rev=${1:-$DEFAULT_REV}
+
+if (( ${#rev} != 40 )); then
+  rev=$(git ls-remote $URL | awk '$2 == "'"$rev"'" { print $1 }')
+fi
+
+nix-prefetch-git --no-deepClone $URL $rev > default.json.new
+mv default.json{.new,}

--- a/pins/racket2nix/default.json
+++ b/pins/racket2nix/default.json
@@ -1,0 +1,7 @@
+{
+  "url": "https://github.com/fractalide/racket2nix.git",
+  "rev": "42915bb9f13c8f1b4f5499b49d7d7a2a8f82aa49",
+  "date": "2018-09-17T00:44:31+08:00",
+  "sha256": "15ixl1yaz2hq0i67yb3g0cc4in5fpzk44j56js9cqwlqykfskdgl",
+  "fetchSubmodules": false
+}

--- a/pins/racket2nix/default.nix
+++ b/pins/racket2nix/default.nix
@@ -1,0 +1,2 @@
+(import <nixpkgs> {}).fetchgit
+  (builtins.removeAttrs (builtins.fromJSON (builtins.readFile ./default.json)) [ "date" ])

--- a/swig/default.nix
+++ b/swig/default.nix
@@ -1,11 +1,15 @@
 { pkgs ? import (import ../pins/nixpkgs) {}
 , ndn-cpp ? pkgs.callPackage ../ndn-cpp {}
+, racket2nix ? import (import ../pins/racket2nix) {}
 }:
 
-let inherit (pkgs) libtool stdenv swig; in
+let
+  inherit (pkgs) libtool stdenv swig;
+  inherit (racket2nix) buildRacketPackage;
+in
 
-stdenv.mkDerivation {
-  name = "rkt-ndn-swig";
+let src = stdenv.mkDerivation {
+  name = "ndn-cpp-lite-bindings";
   nativeBuildInputs = [ libtool swig ndn-cpp ];
   src = ./.;
   buildPhase = ''
@@ -26,9 +30,33 @@ stdenv.mkDerivation {
   '';
 
   installPhase = ''
-    for i in $(find . -name '*_wrap.cxx'); do
+    extensions=$(find lite -name '*_wrap.cxx')
+    for i in $extensions; do
       mkdir -p $out/''${i%/*}
-      cp $i $out/$i
+      cp $i $out/''$i
     done
+    cat > $out/install.rkt <<EOF
+    #lang racket
+
+    (require make/setup-extension)
+    (require dynext)
+
+    (provide pre-installer)
+
+    (define extensions (string-split "$extensions"))
+
+    (define (pre-installer collections-top-path collection-path)
+      (for [(extension extensions)]
+        (eprintf "extension '~a'~n" extension)
+        (pre-install collection-path
+                     (build-path collection-path "private")
+                     extension
+                     "."
+                     '() '() '() '() '() '()
+                     (lambda (thunk) (thunk)))))
+    EOF
+    cp info.rkt $out
   '';
-}
+}; in
+
+buildRacketPackage src

--- a/swig/info.rkt
+++ b/swig/info.rkt
@@ -1,0 +1,5 @@
+#lang setup/infotab
+
+(define collection "ndn-cpp-lite-bindings")
+(define deps '("base" "dynext-lib" "make"))
+(define pre-install-collection "install.rkt")


### PR DESCRIPTION
Solution: Use buildRacket, make and dynext.

Issues:
 - Does not build for 3m Racket, as Swig source is cgc.
 - Does not build anyway, for unknown reason.

If you fake that it's a 3m build (add a parameter \#t after the thunk),
raco/make tries to compile the extension, but fails with:

    make: don't know how to make lite/control-parameters-lite_wrap.cxx

Have not managed to figure out why.